### PR TITLE
Merge[fix/hamburger-dynamic-colo] into [develop]

### DIFF
--- a/themes/twenty-seventeen/assets/css/tagwall-front-page---twenty-seventeen.css
+++ b/themes/twenty-seventeen/assets/css/tagwall-front-page---twenty-seventeen.css
@@ -33,6 +33,20 @@
 	height: 2.46px;
 }
 
+/* Adjusted is-active hamburger squeeze */
+.header-navigation-front-page .hamburger--squeeze.is-active .hamburger-inner{
+	background-color: #A2A4A7;
+}
+
+.header-navigation-front-page .hamburger--squeeze.is-active .hamburger-inner::before{
+	background-color: #A2A4A7;
+}
+
+.header-navigation-front-page .hamburger--squeeze.is-active .hamburger-inner::after{
+	background-color: #A2A4A7;
+}
+
+
 /*--- Only target first level button elements ---*/
 .header-navigation-front-page > button {
 	display: flex;
@@ -42,6 +56,11 @@
 /*--- Hover for first level button elements ---*/
 .header-navigation-front-page > button:hover {
 	opacity: 1;
+}
+
+/* Hide the black tagwall image*/
+.header-navigation-front-page #logo img:first-child{
+	display: none;
 }
 
 /*--- Overriding carousel arrows ---*/

--- a/themes/twenty-seventeen/assets/js/tagwall---twenty-seventeen.js
+++ b/themes/twenty-seventeen/assets/js/tagwall---twenty-seventeen.js
@@ -21,7 +21,11 @@
 			$( '.hamburger' )
 				.toggleClass( 'is-active' );
 
+
 			if ( $( this ).hasClass( 'is-active' ) ) {
+
+				// Hide black tagwall image and display gray one
+				setGrayTagwall();
 
 				$( '.menu-container' )
 					.removeClass( 'not-visible' )
@@ -29,6 +33,9 @@
 
 				$( 'body' ).css( 'overflow', 'hidden' );
 			} else {
+
+				// Hide gray tagwall image and display black one
+				setBlackTagwall();
 
 				// Remove the class 'visible' and add the class 'not-visible' class to the menu container.
 				$( '.menu-container' )
@@ -134,6 +141,26 @@
 			prevArrow     : $( 'i.ion-ios-arrow-left' ),
 			nextArrow     : $( 'i.ion-ios-arrow-right' )
 		});
+
+		/**
+		 * Sets black tagwall image
+		 */
+		function setBlackTagwall(){
+			$( '.header-navigation-front-page #logo img:first-child')
+				.css({ "display" : "none" });
+			$( '.header-navigation-front-page #logo img:last-child')
+				.css({ "display" : "block" });
+		}
+
+		/**
+		 * Sets gray tagwall image
+		 */
+		function setGrayTagwall(){
+			$( '.header-navigation-front-page #logo img:first-child')
+				.css({ "display" : "block" });
+			$( '.header-navigation-front-page #logo img:last-child')
+				.css({ "display" : "none" });
+		}
 
 	});
 } )( jQuery );

--- a/themes/twenty-seventeen/assets/lib/hamburger/hamburger.css
+++ b/themes/twenty-seventeen/assets/lib/hamburger/hamburger.css
@@ -35,7 +35,7 @@
   .hamburger-inner, .hamburger-inner::before, .hamburger-inner::after {
     width: 40px;
     height: 4px;
-    background-color: #A2A4A7;
+    background-color: #000;  
     border-radius: 4px;
     position: absolute;
     transition-property: transform;
@@ -565,6 +565,7 @@
   .hamburger--squeeze.is-active .hamburger-inner::before {
     top: 0;
     opacity: 0;
+    transition: 0.5s background-color ease-in-out;
     transition: top 0.1s ease, opacity 0.1s 0.14s ease; }
   .hamburger--squeeze.is-active .hamburger-inner::after {
     bottom: 0;

--- a/themes/twenty-seventeen/partials/content-header-navigation-front-page.php
+++ b/themes/twenty-seventeen/partials/content-header-navigation-front-page.php
@@ -12,6 +12,7 @@
 	<section id="logo">
 		<a href="<?php echo home_url(); ?>">
 			<img src="<?php echo TAGWALL_TEMPLATE_URL . '/assets/images/tagwall.png'; ?>" />
+			<img src="<?php echo TAGWALL_TEMPLATE_URL . '/assets/images/tagwall-black.png'; ?>" />
 		</a>
 	</section>
 


### PR DESCRIPTION
By altering the psuedo elements, the hamburger menu button color changes when the `.is-active` class is toggled.  The tagwall logo image is also switched on this event